### PR TITLE
change the 404 link

### DIFF
--- a/content/lab5/lab5.ipynb
+++ b/content/lab5/lab5.ipynb
@@ -215,7 +215,8 @@
     "\n",
     "You may find it helpful to consult the following resources:\n",
     "  - https://qiskit.org/ecosystem/aer/apidocs/aer_noise.html\n",
-    "  - https://qiskit.org/documentation/tutorials/simulators/3_building_noise_models.html"
+    "  - https://qiskit.org/ecosystem/aer/tutorials/3_building_noise_models.html\n",
+    "  "
    ]
   },
   {


### PR DESCRIPTION
The lab 5 has the link https://qiskit.org/documentation/tutorials/simulators/3_building_noise_models.html but this is 404 the correct one is 
 https://qiskit.org/ecosystem/aer/tutorials/3_building_noise_models.html